### PR TITLE
Adding setting existing token; Adding option to disable friends photos

### DIFF
--- a/BSFacebookImagePicker/Public/BSFacebookImagePickerController.h
+++ b/BSFacebookImagePicker/Public/BSFacebookImagePickerController.h
@@ -48,6 +48,16 @@
  */
 @property(nonatomic, assign) id <BSFacebookImagePickerControllerDelegate, UINavigationControllerDelegate> delegate;
 
+/*!
+ @method     setExistingFacebookAcessToken:expiryDate:
+ @abstract   Sets an existing authToken for apps that have already authenticated the user with Facebook
+ @discussion The token passed should include the following permissions: "user_photos,friends_photos". When using this method, set the app id and secret as well, so once the token expires, BSFacebookImagePickerController would be able to extend the token.
+ @param      token   The Facebook Token to use for for querying Facebook.
+ @param      expiry         The expiration date of the provided token
+
+ */
+
++ (void)setExistingFacebookAcessToken:(NSString *)token expiryDate:(NSDate *)expiry;
 
 /*!
  @method     handleCallbackURL:
@@ -94,4 +104,5 @@
  @param      controller   The BSFacebookImagePickerController instance which is returning the result.
  */
 - (void)imagePickerControllerDidCancel:(BSFacebookImagePickerController *)picker;
+
 @end

--- a/BSFacebookImagePicker/Public/BSFacebookImagePickerController.h
+++ b/BSFacebookImagePicker/Public/BSFacebookImagePickerController.h
@@ -42,6 +42,13 @@
 @property (nonatomic) NSString *facebookAppSecret;
 
 /*!
+ @property   showFriendsPhotos
+ @abstract   Whether to show friends' photos as well.
+ @discussion If an existing token is passed to BSFacebookImagePickerController and showFriendsPhotos is not set to NO, ensure that the token has the "friends_photos" permission. The default value is YES
+ */
+@property (nonatomic) BOOL showFriendsPhotos;
+
+/*!
  @property   delegate
  @abstract   The delegate to be assigned to notify the client when a photo has been chosen, an error has occured, or
              the user has canceled.
@@ -50,7 +57,7 @@
 /*!
  @method     setExistingFacebookAcessToken:expiryDate:
  @abstract   Sets an existing authToken for apps that have already authenticated the user with Facebook
- @discussion The token passed should include the following permissions: "user_photos,friends_photos". When using this method, set the app id and secret as well, so once the token expires, BSFacebookImagePickerController would be able to extend the token.
+ @discussion The token passed should include the following permissions: "user_photos,friends_photos". If showFriendsPhotos is set to NO, only "user_photos" is required. When using this method, set the app id and secret as well, so once the token expires, BSFacebookImagePickerController would be able to extend the token.
  @param      token   The Facebook Token to use for for querying Facebook.
  @param      expiry         The expiration date of the provided token
  

--- a/BSFacebookImagePicker/Public/BSFacebookImagePickerController.h
+++ b/BSFacebookImagePicker/Public/BSFacebookImagePickerController.h
@@ -47,17 +47,17 @@
              the user has canceled.
  */
 @property(nonatomic, assign) id <BSFacebookImagePickerControllerDelegate, UINavigationControllerDelegate> delegate;
-
 /*!
  @method     setExistingFacebookAcessToken:expiryDate:
  @abstract   Sets an existing authToken for apps that have already authenticated the user with Facebook
  @discussion The token passed should include the following permissions: "user_photos,friends_photos". When using this method, set the app id and secret as well, so once the token expires, BSFacebookImagePickerController would be able to extend the token.
  @param      token   The Facebook Token to use for for querying Facebook.
  @param      expiry         The expiration date of the provided token
-
+ 
  */
 
-+ (void)setExistingFacebookAcessToken:(NSString *)token expiryDate:(NSDate *)expiry;
+- (void)setExistingFacebookAcessToken:(NSString *)token expiryDate:(NSDate *)expiry;
+
 
 /*!
  @method     handleCallbackURL:

--- a/BSFacebookImagePicker/Source/BSFacebookImagePickerController.m
+++ b/BSFacebookImagePicker/Source/BSFacebookImagePickerController.m
@@ -29,7 +29,7 @@ static CGSize kPopoverSize = {320, 480};
 
 @implementation BSFacebookImagePickerController
 
-+ (void)setExistingFacebookAcessToken:(NSString *)token expiryDate:(NSDate *)expiry {
+- (void)setExistingFacebookAcessToken:(NSString *)token expiryDate:(NSDate *)expiry {
     [[BSFacebook sharedInstance] setAccessToken:token];
     [[BSFacebook sharedInstance] setAccessTokenExpiryDate:expiry];
 }

--- a/BSFacebookImagePicker/Source/BSFacebookImagePickerController.m
+++ b/BSFacebookImagePicker/Source/BSFacebookImagePickerController.m
@@ -29,6 +29,11 @@ static CGSize kPopoverSize = {320, 480};
 
 @implementation BSFacebookImagePickerController
 
++ (void)setExistingFacebookAcessToken:(NSString *)token expiryDate:(NSDate *)expiry {
+    [[BSFacebook sharedInstance] setAccessToken:token];
+    [[BSFacebook sharedInstance] setAccessTokenExpiryDate:expiry];
+}
+
 + (void)handleCallbackURL:(NSURL *)url {
   [[BSFacebook sharedInstance] handleCallbackURL:url];
 }

--- a/BSFacebookImagePicker/Source/BSFacebookImagePickerController.m
+++ b/BSFacebookImagePicker/Source/BSFacebookImagePickerController.m
@@ -69,6 +69,8 @@ static CGSize kPopoverSize = {320, 480};
     [[BSFacebook sharedInstance] setFacebookAppSecret:facebookAppSecret];
 }
 
-
+- (void)setShowFriendsPhotos:(BOOL)showFriendsPhotos{
+    [[BSFacebook sharedInstance] setShowFriendsPhotos:showFriendsPhotos];
+}
 
 @end

--- a/BSFacebookImagePicker/Source/FacebookAuth/BSFacebook.h
+++ b/BSFacebookImagePicker/Source/FacebookAuth/BSFacebook.h
@@ -49,6 +49,7 @@ typedef void (^BSFBLoginErrorBlock)();
 @property (nonatomic, strong) NSString *urlSchemeSuffix;
 @property (nonatomic, strong) NSString *accessToken;
 @property (nonatomic, strong) NSDate *accessTokenExpiryDate;
+@property (nonatomic) BOOL showFriendsPhotos;
 
 + (BSFacebook *)sharedInstance;
 

--- a/BSFacebookImagePicker/Source/FacebookAuth/BSFacebook.h
+++ b/BSFacebookImagePicker/Source/FacebookAuth/BSFacebook.h
@@ -48,6 +48,7 @@ typedef void (^BSFBLoginErrorBlock)();
 @property (nonatomic, strong) NSString *facebookAppSecret;
 @property (nonatomic, strong) NSString *urlSchemeSuffix;
 @property (nonatomic, strong) NSString *accessToken;
+@property (nonatomic, strong) NSDate *accessTokenExpiryDate;
 
 + (BSFacebook *)sharedInstance;
 

--- a/BSFacebookImagePicker/Source/FacebookAuth/BSFacebook.m
+++ b/BSFacebookImagePicker/Source/FacebookAuth/BSFacebook.m
@@ -29,7 +29,6 @@ NSString * const kJSFacebookSSOAuthURL                  = @"fbauth://authorize/"
 
 @property (nonatomic, copy) BSFBLoginSuccessBlock authSuccessBlock;
 @property (nonatomic, copy) BSFBLoginErrorBlock authErrorBlock;
-@property (nonatomic, strong) NSDate *accessTokenExpiryDate;
 
 @end
 

--- a/BSFacebookImagePicker/Source/FacebookAuth/BSFacebook.m
+++ b/BSFacebookImagePicker/Source/FacebookAuth/BSFacebook.m
@@ -52,6 +52,7 @@ NSString * const kJSFacebookSSOAuthURL                  = @"fbauth://authorize/"
 @synthesize facebookAppID=_facebookAppID;
 @synthesize facebookAppSecret=_facebookAppSecret;
 @synthesize urlSchemeSuffix=_urlSchemeSuffix;
+@synthesize showFriendsPhotos=_showFriendsPhotos;
 @synthesize authErrorBlock;
 @synthesize authSuccessBlock;
 
@@ -85,6 +86,7 @@ NSString * const kJSFacebookSSOAuthURL                  = @"fbauth://authorize/"
 				self.accessTokenExpiryDate = accessTokenExpiryDate;
 			}
 		}
+        _showFriendsPhotos = YES;
 	}
 	return self;
 }

--- a/BSFacebookImagePicker/Source/PrivateViewControllers/BSFBAlbumPickerController.m
+++ b/BSFacebookImagePicker/Source/PrivateViewControllers/BSFBAlbumPickerController.m
@@ -35,6 +35,20 @@ static NSString *albumPlaceholderImageName = @"BSFBAlbumPicker.bundle/albumPlace
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
   UITableViewCell *tvc = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    NSString *picture = (self.items)[indexPath.row][@"photos"][@"data"][0][@"picture"];
+    
+    tvc.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    
+    tvc.imageView.clipsToBounds = YES;
+    tvc.imageView.contentMode = UIViewContentModeScaleAspectFill;
+    //  [tvc.imageView setImage:[UIImage imageNamed:albumPlaceholderImageName]];
+    
+    UIImageView *iv = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 60, 60)];
+    [iv setImageWithURL:[NSURL URLWithString:picture] placeholderImage:[UIImage imageNamed:albumPlaceholderImageName]];
+    //   [iv setImageWithURL:[NSURL URLWithString:picture]];
+    iv.clipsToBounds = YES;
+    [tvc.contentView addSubview:iv];
+    
   tvc.textLabel.lineBreakMode = NSLineBreakByWordWrapping;
   tvc.textLabel.numberOfLines = 0;
   
@@ -44,7 +58,6 @@ static NSString *albumPlaceholderImageName = @"BSFBAlbumPicker.bundle/albumPlace
   NSString *string = [NSString stringWithFormat:@"%@ (%@)",albumName,(count?count:@"0")];
   UIFont *font = [UIFont fontWithName:@"Helvetica" size:15];
   UIColor *textColor = [UIColor blackColor];
-  
   
   //Set -[UILabel setAttributedText:] is only avaialble in iOS 6+]
   //On iOS 6+ we bold the album name.
@@ -68,20 +81,7 @@ static NSString *albumPlaceholderImageName = @"BSFBAlbumPicker.bundle/albumPlace
     [tvc.textLabel setTextColor:textColor];
     [tvc.textLabel setText:string];
   }
-  
-  
-  NSString *picture = (self.items)[indexPath.row][@"photos"][@"data"][0][@"picture"];
-  
-  tvc.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-  
-  tvc.imageView.clipsToBounds = YES;
-  tvc.imageView.contentMode = UIViewContentModeScaleAspectFill;
-  [tvc.imageView setImage:[UIImage imageNamed:albumPlaceholderImageName]];
-  
-  UIImageView *iv = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 60, 60)];
-  [iv setImageWithURL:[NSURL URLWithString:picture] placeholderImage:[UIImage imageNamed:albumPlaceholderImageName]];
-  [tvc.contentView addSubview:iv];
-  
+    tvc.textLabel.textAlignment = UITextAlignmentRight;
   return tvc;
 }
 

--- a/BSFacebookImagePicker/Source/PrivateViewControllers/BSFBPhotoGridViewController.m
+++ b/BSFacebookImagePicker/Source/PrivateViewControllers/BSFBPhotoGridViewController.m
@@ -28,6 +28,7 @@
 -(void) viewDidLoad {
   [super viewDidLoad];
   self.tableView.rowHeight = 80;
+  self.edgesForExtendedLayout=UIRectEdgeNone;
 }
 
 

--- a/BSFacebookImagePicker/Source/PrivateViewControllers/BSFBRootViewController.m
+++ b/BSFacebookImagePicker/Source/PrivateViewControllers/BSFBRootViewController.m
@@ -83,9 +83,14 @@
 }
 
 -(void) setupToolbar {
-  UISegmentedControl *segmentedControl = [[UISegmentedControl alloc] initWithItems:@[Localized(@"PHOTOS_OF_YOU"),
-                                                                                     Localized(@"ALBUMS"),
-                                                                                     Localized(@"FRIENDS")]];
+  NSMutableArray *segments = [@[Localized(@"PHOTOS_OF_YOU"),
+                                Localized(@"ALBUMS"),
+                                Localized(@"FRIENDS")] mutableCopy];
+  if (![BSFacebook sharedInstance].showFriendsPhotos) {
+        [segments removeObject:Localized(@"FRIENDS")];
+  }
+    
+  UISegmentedControl *segmentedControl = [[UISegmentedControl alloc] initWithItems:segments];
   segmentedControl.segmentedControlStyle = UISegmentedControlStyleBar;
   segmentedControl.selectedSegmentIndex = 1;
   [segmentedControl addTarget:self action:@selector(segmentedControlValueDidChange:) forControlEvents:UIControlEventValueChanged];

--- a/BSFacebookImagePicker/Source/PrivateViewControllers/BSFBRootViewController.m
+++ b/BSFacebookImagePicker/Source/PrivateViewControllers/BSFBRootViewController.m
@@ -54,8 +54,12 @@
     photosOfYou.url = [NSURL URLWithString:path];
     
     BSFBFriendsViewController *friendsViewController = [[BSFBFriendsViewController alloc] init];
-    
-    self.viewControllers = @[photosOfYou,albumPicker,friendsViewController];
+    NSMutableArray *controllers = [@[photosOfYou,albumPicker,friendsViewController] mutableCopy];
+    if (![BSFacebook sharedInstance].showFriendsPhotos) {
+        [controllers removeObject:friendsViewController];
+    }
+  
+    self.viewControllers = controllers;
     
     _currentViewController = albumPicker;
     
@@ -153,7 +157,11 @@
 #pragma mark -
 #pragma mark Buttons
 - (void)loginButtonPressed:(id)sender {
-	NSArray *permissions = @[@"user_photos,friends_photos"];
+    
+	NSMutableArray *permissions = [@[@"user_photos,friends_photos"] mutableCopy];
+    if (![BSFacebook sharedInstance].showFriendsPhotos) {
+        [permissions removeObject:@"friends_photos"];
+    }
   [[BSFacebook sharedInstance] loginWithPermissions:permissions onSuccess:^(void) {
     [[NSNotificationCenter defaultCenter] postNotificationName:@"USER_DID_LOGIN" object:nil];
     NSLog(@"Sucessfully logged in!");

--- a/BSFacebookImagePicker/Source/PrivateViewControllers/BSFBRootViewController.m
+++ b/BSFacebookImagePicker/Source/PrivateViewControllers/BSFBRootViewController.m
@@ -76,6 +76,7 @@
   self.title = Localized(@"CHOOSE_ALBUM");
   self.view.backgroundColor = [UIColor greenColor];
   [self setupCancelButton];
+  self.edgesForExtendedLayout=UIRectEdgeNone;
   [self.view addSubview:_currentViewController.view];
   _currentViewController.view.frame = self.view.bounds;
   [(BSFBAlbumPickerController *)_currentViewController setNavigationController:self.navigationController];


### PR DESCRIPTION
Hey Brad,

1) Added the setToken:expiry method as you suggested. 
2) Added showFriendsPhotos property (default YES) to enable/disable "friends photos". This affects the requested permissions as well as the UI elements.

I could not test what would happen once the passed token expires.

P.S. Don't forget to tag 1.0.0, so it can be pulled from cocoapods.

Best,
Israel
